### PR TITLE
Change width of component, reposition inputs below calendar

### DIFF
--- a/css/DateInput.scss
+++ b/css/DateInput.scss
@@ -1,5 +1,3 @@
-$caret-top: $react-dates-spacing-vertical-picker - $react-dates-width-tooltip-arrow / 2;
-
 .DateInput {
   // font
   font-weight: 200;
@@ -14,28 +12,6 @@ $caret-top: $react-dates-spacing-vertical-picker - $react-dates-width-tooltip-ar
   display: inline-block;
   width: $react-dates-width-input;
   vertical-align: middle;
-}
-
-.DateInput--with-caret::before,
-.DateInput--with-caret::after {
-  content: "";
-  display: inline-block;
-  position: absolute;
-  bottom: auto;
-  border: $react-dates-width-tooltip-arrow / 2 solid transparent;
-  border-top: 0;
-  left: 22px;
-  z-index: 2;
-}
-
-.DateInput--with-caret::before {
-  top: $caret-top;
-  border-bottom-color: rgba(0, 0, 0, 0.1);
-}
-
-.DateInput--with-caret::after {
-  top: $caret-top + 1;
-  border-bottom-color: $react-dates-color-white;
 }
 
 .DateInput--disabled {

--- a/css/DateRangePicker.scss
+++ b/css/DateRangePicker.scss
@@ -17,18 +17,8 @@
 }
 
 .DateRangePicker__picker {
-  z-index: 1;
   background-color: $react-dates-color-white;
-  position: absolute;
   top: $react-dates-spacing-vertical-picker;
-}
-
-.DateRangePicker__picker--show {
-  visibility: visible;
-}
-
-.DateRangePicker__picker--invisible {
-  visibility: hidden;
 }
 
 .DateRangePicker__picker--direction-left {

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -103,11 +103,8 @@ export default class DateRangePicker extends React.Component {
       withFullScreenPortal,
       anchorDirection,
     } = this.props;
-    const showDatepicker = focusedInput === START_DATE || focusedInput === END_DATE;
 
     const dayPickerClassName = cx('DateRangePicker__picker', {
-      'DateRangePicker__picker--show': showDatepicker,
-      'DateRangePicker__picker--invisible': !showDatepicker,
       'DateRangePicker__picker--direction-left': anchorDirection === ANCHOR_LEFT,
       'DateRangePicker__picker--direction-right': anchorDirection === ANCHOR_RIGHT,
       'DateRangePicker__picker--horizontal': orientation === HORIZONTAL_ORIENTATION,
@@ -262,6 +259,8 @@ export default class DateRangePicker extends React.Component {
 
     return (
       <div className="DateRangePicker">
+        {this.maybeRenderDayPickerWithPortal()}
+
         <DateRangePickerInputController
           startDate={startDate}
           startDateId={startDateId}
@@ -284,8 +283,6 @@ export default class DateRangePicker extends React.Component {
           onFocusChange={onFocusChange}
           phrases={phrases}
         />
-
-        {this.maybeRenderDayPickerWithPortal()}
       </div>
     );
   }

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -14,7 +14,7 @@ import OrientationShape from '../shapes/OrientationShape';
 
 import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
 
-const CALENDAR_MONTH_WIDTH = 300;
+const CALENDAR_MONTH_WIDTH = 246;
 const DAY_PICKER_PADDING = 9;
 const MONTH_PADDING = 23;
 const PREV_TRANSITION = 'prev';


### PR DESCRIPTION
The width change allows for 2 calendars with our intended padding (defined in our Racine Component stylesheet). I think we might want to clarify this later on so the number does not seem so arbitrary `CALENDAR_MONTH_WIDTH`