### PR TITLE
Adding inline calendar property for presentation

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -321,7 +321,7 @@ export default class DateRangePicker extends React.Component {
             isEndDateFocused={focusedInput === END_DATE}
             displayFormat={displayFormat}
             showClearDates={showClearDates}
-            showCaret={!withPortal && !withFullScreenPortal}
+            showCaret={!withPortal && !withFullScreenPortal && !withInlineCalendar}
             showDefaultInputIcon={showDefaultInputIcon}
             customInputIcon={customInputIcon}
             customArrowIcon={customArrowIcon}

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -57,6 +57,7 @@ const defaultProps = {
   horizontalMargin: 0,
   withPortal: false,
   withFullScreenPortal: false,
+  withInlineCalendar: false,
 
   onDatesChange() {},
   onFocusChange() {},
@@ -292,6 +293,7 @@ export default class DateRangePicker extends React.Component {
       isOutsideRange,
       withPortal,
       withFullScreenPortal,
+      withInlineCalendar,
       displayFormat,
       reopenPickerOnClearDates,
       keepOpenOnDateSelect,
@@ -300,39 +302,43 @@ export default class DateRangePicker extends React.Component {
       renderDay,
     } = this.props;
 
-    const onOutsideClick = (!withPortal && !withFullScreenPortal) ? this.onOutsideClick : undefined;
+    const onOutsideClick = (!withPortal && !withFullScreenPortal && !withInlineCalendar)
+      ? this.onOutsideClick
+      : undefined;
 
     return (
       <div className="DateRangePicker">
-        {this.maybeRenderDayPickerWithPortal()}
-
-        <DateRangePickerInputController
-          startDate={startDate}
-          startDateId={startDateId}
-          startDatePlaceholderText={startDatePlaceholderText}
-          isStartDateFocused={focusedInput === START_DATE}
-          endDate={endDate}
-          endDateId={endDateId}
-          endDatePlaceholderText={endDatePlaceholderText}
-          isEndDateFocused={focusedInput === END_DATE}
-          displayFormat={displayFormat}
-          showClearDates={showClearDates}
-          showCaret={!withPortal && !withFullScreenPortal}
-          showDefaultInputIcon={showDefaultInputIcon}
-          customInputIcon={customInputIcon}
-          customArrowIcon={customArrowIcon}
-          disabled={disabled}
-          required={required}
-          reopenPickerOnClearDates={reopenPickerOnClearDates}
-          keepOpenOnDateSelect={keepOpenOnDateSelect}
-          isOutsideRange={isOutsideRange}
-          withFullScreenPortal={withFullScreenPortal}
-          onDatesChange={onDatesChange}
-          onFocusChange={onFocusChange}
-          renderDay={renderDay}
-          phrases={phrases}
-          screenReaderMessage={screenReaderInputMessage}
-        />
+        <OutsideClickHandler onOutsideClick={onOutsideClick}>
+          {withInlineCalendar && this.maybeRenderDayPickerWithPortal()}
+          <DateRangePickerInputController
+            startDate={startDate}
+            startDateId={startDateId}
+            startDatePlaceholderText={startDatePlaceholderText}
+            isStartDateFocused={focusedInput === START_DATE}
+            endDate={endDate}
+            endDateId={endDateId}
+            endDatePlaceholderText={endDatePlaceholderText}
+            isEndDateFocused={focusedInput === END_DATE}
+            displayFormat={displayFormat}
+            showClearDates={showClearDates}
+            showCaret={!withPortal && !withFullScreenPortal}
+            showDefaultInputIcon={showDefaultInputIcon}
+            customInputIcon={customInputIcon}
+            customArrowIcon={customArrowIcon}
+            disabled={disabled}
+            required={required}
+            reopenPickerOnClearDates={reopenPickerOnClearDates}
+            keepOpenOnDateSelect={keepOpenOnDateSelect}
+            isOutsideRange={isOutsideRange}
+            withFullScreenPortal={withFullScreenPortal}
+            onDatesChange={onDatesChange}
+            onFocusChange={onFocusChange}
+            renderDay={renderDay}
+            phrases={phrases}
+            screenReaderMessage={screenReaderInputMessage}
+          />
+          {!withInlineCalendar && this.maybeRenderDayPickerWithPortal()}
+        </OutsideClickHandler>
       </div>
     );
   }

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -157,6 +157,11 @@ storiesOf('DateRangePicker', module)
       />
     </div>
   ))
+  .addWithInfo('with inlined calendar', () => (
+    <DateRangePickerWrapper
+      withInlineCalendar
+    />
+  ))
   .addWithInfo('horizontal with portal', () => (
     <DateRangePickerWrapper
       withPortal


### PR DESCRIPTION
* Adding withInlineCalendar prop allowing for the following scenarios:
** If withInlineCalendar is set to true the consumer will have the calendar visible at all times with the date range inputs below.
** If withInlineCalendar is set to false the consumer will have the date range inputs visible always and the calendar will only display when one of the inputs has focus (e.g. the user is in the process of selecting a date range)